### PR TITLE
Fix symbolic link handling and update GitHub repository URI in setup scripts

### DIFF
--- a/config/install-dotfiles-windows.ps1
+++ b/config/install-dotfiles-windows.ps1
@@ -13,10 +13,12 @@ Get-ChildItem -Directory $SourceFolder | ForEach-Object {
     $TargetPath = Join-Path -Path $TargetFolder -ChildPath $_.Name
 
     if (Test-Path $TargetPath) {
-        if (-not (Test-Path $TargetPath -PathType SymbolicLink)) {
-            Rename-Item -Path $TargetPath -NewName "$($TargetPath).backup"
+        $TargetItem = Get-Item -Path $TargetPath -ErrorAction SilentlyContinue
+        # シンボリックリンクかどうかを確認
+        if ($TargetItem -and $TargetItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+            Remove-Item -Path $TargetPath -Force
         } else {
-            Remove-Item -Path $TargetPath
+            Rename-Item -Path $TargetPath -NewName "$($TargetPath).backup"
         }
     }
 

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1,6 +1,6 @@
 $GitRepositoryHost = "https://github.com"
-$GitUserName = "nepta"
-$GitRepositoryUri = "{0}/{1}/dotfiles.git" -f $GitRepositoryHost, $GitUserName
+$GitUserName = "neputa"
+$GitRepositoryUri = "{0}/{1}/dotfiles" -f $GitRepositoryHost, $GitUserName
 $GitBranch = "main"
 $DotfilesFolderName = ".dotfiles"
 $DotfilesFolderPath = Join-Path -Path $HOME -ChildPath $DotfilesFolderName


### PR DESCRIPTION
Improve symbolic link management by ensuring proper handling and removal, while also correcting the GitHub repository URI format in the setup scripts.